### PR TITLE
Merge release-1.2 bugfixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,5 @@ jobs:
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,5 @@ jobs:
         uses: BigWigsMods/packager@v2
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.2.3 - 2025-01-16
+
+### Fix
+
+- WoD Timewalking LFD is not recognized
+- Siren Isle Invasion is not recognized until Storm phase is activated
+
 ## v1.2.2 - 2025-01-14
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.2.1 - 2025-01-13
+
+### Fix
+
+- Progress isn't marked as 100% for claimed rewards. i.e. Siren Isle Special Assignment quest
+- Drops aren't  linked to rewards in multi-reward quests sometimes.
+- New SA quest aren't recognized
+
 ## v1.2.0 - 2025-01-12
 
 Supports tracking the Great Vault rewards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.2 - 2025-01-14
+
+### Fix
+
+- Spider Weekly progress is not shown until Pact quest is completed
+
 ## v1.2.1 - 2025-01-13
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.4 - 2025-02-04
+
+### Fix
+
+- Cannot recognize Special Assignment: Titanic Resurgence
+
 ## v1.2.3 - 2025-01-16
 
 ### Fix

--- a/Core/Character.lua
+++ b/Core/Character.lua
@@ -156,7 +156,7 @@ function Character:UpdateRewardsGUID(quest)
 	end
 
 	local includeOldItems = quest == nil
-	local found = false
+	local found = 0
 	for containerIndex = BACKPACK_CONTAINER, NUM_TOTAL_EQUIPPED_BAG_SLOTS do
 		for slotIndex = 1, C_Container.GetContainerNumSlots(containerIndex) do
 			local info = C_Container.GetContainerItemInfo(containerIndex, slotIndex)
@@ -172,14 +172,14 @@ function Character:UpdateRewardsGUID(quest)
 				end
 
 				if item.guid or item.guid == false then
-					found = true
+					found = found + 1
 					Util:Debug("guid updated for ", info.hyperlink, info.stackCount, containerIndex, slotIndex, item.guid)
 				end
 			end
 		end
 	end
 
-	return found
+	return found == count
 end
 
 function Character:ReceiveDrop(guid, quantity, itemId, currencyId)

--- a/Core/Progress.lua
+++ b/Core/Progress.lua
@@ -200,6 +200,13 @@ function RewardProgress:Update(completedQuest)
 		end
 	end
 
+	for i, objective in ipairs(self.fulfilledObjectives) do
+		if objective.removeOnCompletion then
+			table.remove(self.fulfilledObjectives, i)
+			Util:Debug("Removed completed objective: ", self.name)
+		end
+	end
+
 	if #self.pendingObjectives == 0 then
 		newState = PROGRESS_STATE.CLAIMED
 		-- Cannot update the records here since the progress is already lost

--- a/Core/Progress.lua
+++ b/Core/Progress.lua
@@ -106,6 +106,16 @@ function RewardProgress:_AddRecord(record)
 	table.insert(self.records, record)
 end
 
+-- Mark records as done manualy, we cannot get progress=100% update sometime before
+function RewardProgress:_FinalizeRecords()
+	for _, record in ipairs(self.records or {}) do
+		if record.fulfilled ~= record.required then
+			record.text = string.gsub(record.text, record.fulfilled, record.required)
+			record.fulfilled = record.required
+		end
+	end
+end
+
 function RewardProgress:_UpdateRecords()
 	-- Reset progress
 	self.position = 0
@@ -192,6 +202,8 @@ function RewardProgress:Update(completedQuest)
 
 	if #self.pendingObjectives == 0 then
 		newState = PROGRESS_STATE.CLAIMED
+		-- Cannot update the records here since the progress is already lost
+		self:_FinalizeRecords()
 	elseif #self.fulfilledObjectives > 0 then
 		-- Multi rewards scenerio
 		newState = PROGRESS_STATE.IN_PROGRESS

--- a/Core/Reward.lua
+++ b/Core/Reward.lua
@@ -67,14 +67,16 @@ function Reward:DetermineObjectives(entries, pick)
 				if WAPI_GetPlayerAuraBySpellID(entry.unlockAura) then
 					confirmed = true
 				end
-			else
-				local quest = entry.unlockQuest or entry.quest
-
+			elseif entry.unlockQuest then
 				if
-					WAPI_IsOnQuest(quest)
-					or (entry.unlockQuest and WAPI_IsQuestFlaggedCompleted(quest)) -- i.e. Spider Pact
-					or WAPI_GetQuestTimeLeftSeconds(quest)
+					WAPI_IsOnQuest(entry.unlockQuest)
+					or WAPI_GetQuestTimeLeftSeconds(entry.unlockQuest)
+					or (WAPI_IsQuestFlaggedCompleted(entry.unlockQuest) and WAPI_IsOnQuest(entry.quest)) -- i.e. Spider Pact
 				then
+					confirmed = true
+				end
+			else
+				if WAPI_IsOnQuest(entry.quest) or WAPI_GetQuestTimeLeftSeconds(entry.quest) then
 					confirmed = true
 				end
 			end
@@ -111,7 +113,7 @@ function Reward:DetermineState(pick)
 	if #self.objectives == pick and self.resetTime then
 		self.state = STATE.CONFIRMED
 	else
-		Util:Debug("Cannot determine reset time for " .. self.name)
+		Util:Debug("Cannot determine reset time for " .. self.name, #self.objectives, self.resetTime)
 	end
 end
 
@@ -124,7 +126,7 @@ function Reward:DetermineResetTime(timeLeft)
 		-- Cannot always get valid reset time when just logged in
 		for _, objective in ipairs(self.objectives) do
 			for _, quest in ipairs({ objective.quest, objective.unlockQuest }) do
-				timeLeft = WAPI_GetQuestTimeLeftSeconds(objective.quest)
+				timeLeft = WAPI_GetQuestTimeLeftSeconds(quest)
 				if timeLeft then
 					break
 				end

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -244,11 +244,13 @@ namespace.DB.rewardCandidiates["tww"] = {
 	{
 		id = "tww-invasion",
 		key = "Invasion",
-		description = "Siren Isle Invasion and Storm Weekly Quests",
+		description = "Siren Isle Invasion Quests|n|n"
+			.. "Enemies cycle every week from a pool of three types:|n"
+			.. "|cffffff00Vrykul|r, |cffffff00Naga|r, and |cffffff00Pirate|r.",
 		group = RewardsGroup.SIREN_ISLE,
 		minimumLevel = 80,
 		timeLeft = C_DateAndTime.GetSecondsUntilWeeklyReset,
-		pick = 7,
+		pick = 5,
 		entries = {
 			-- Vrykul Invasion - Unlock by Legacy of the Vrykul
 			{ quest = 84248, unlockQuest = 84852 }, -- A Ritual of Runes
@@ -268,9 +270,6 @@ namespace.DB.rewardCandidiates["tww"] = {
 			{ quest = 84001, unlockQuest = 84851 }, -- Cart Blanche
 			{ quest = 84299, unlockQuest = 84851 }, -- Pirate Plunder
 			{ quest = 84619, unlockQuest = 84851 }, -- Ooker Dooker Literature Club
-			-- Storm Active Phase: In Seafury Tempest
-			{ quest = 84225 }, -- Eggstinction
-			{ quest = 84241 }, -- Shoreline Stand
 		},
 	},
 	{

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -129,6 +129,8 @@ namespace.DB.rewardCandidiates["tww"] = {
 		entries = {
 			{ quest = 82355, unlockQuest = 82146 }, -- Special Assignment: Cinderbee Surge
 			{ quest = 81647, unlockQuest = 82154 }, -- Special Assignment: Titanic Resurgence
+			{ quest = 81649, unlockQuest = 83069 }, -- Special Assignment: Titanic Resurgence
+			{ quest = 81650, unlockQuest = 83070 }, -- Special Assignment: Titanic Resurgence
 			{ quest = 81691, unlockQuest = 82155 }, -- Special Assignment: Shadows Below
 			{ quest = 83229, unlockQuest = 82156 }, -- Special Assignment: When the Deeps Stir
 			{ quest = 82787, unlockQuest = 82157 }, -- Special Assignment: Rise of the Colossals

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -153,8 +153,13 @@ namespace.DB.rewardCandidiates["tww"] = {
 		group = RewardsGroup.WEEKLY_CACHE,
 		minimumLevel = 70,
 		timeLeft = C_DateAndTime.GetSecondsUntilWeeklyReset,
+		pick = 2,
 		rollover = true,
 		entries = {
+			{
+				quest = 80592, -- Forge a pact
+				removeOnCompletion = true,
+			},
 			{
 				quest = 80670,
 				questPool = {

--- a/DB/Timewalking.lua
+++ b/DB/Timewalking.lua
@@ -48,7 +48,7 @@ namespace.DB.rewardCandidiates["timewalking"] = {
 					167921,
 					167922,
 				},
-				unlockAura = 335150, -- Sign of Iron
+				unlockAura = 335152, -- Sign of Iron
 				questPool = {
 					55498, --[WoD] Alliance: The Shimmering Crystal
 					55499, --[WoD] Horde: The Shimmering Crystal er

--- a/WeeklyRewards.toc
+++ b/WeeklyRewards.toc
@@ -6,6 +6,7 @@
 ## SavedVariables: WeeklyRewardsDB, WeeklyRewardsArchive
 ## X-Website: https://github.com/cybertk/WeeklyRewards
 ## X-Curse-Project-ID: 1171512
+## X-Wago-ID: rN4VlYKD
 
 
 Embeds.xml

--- a/WeeklyRewards.toc
+++ b/WeeklyRewards.toc
@@ -7,6 +7,7 @@
 ## X-Website: https://github.com/cybertk/WeeklyRewards
 ## X-Curse-Project-ID: 1171512
 ## X-Wago-ID: rN4VlYKD
+## X-WoWI-ID: 26890
 
 
 Embeds.xml


### PR DESCRIPTION
### Fix

- Cannot recognize Special Assignment: Titanic Resurgence
- WoD Timewalking LFD is not recognized
- Siren Isle Invasion is not recognized until Storm phase is activated
- Spider Weekly progress is not shown until Pact quest is completed
- Progress isn't marked as 100% for claimed rewards. i.e. Siren Isle Special Assignment quest
- Drops aren't linked to rewards in multi-reward quests sometimes.
- New SA quest aren't recognized