### PR TITLE
Merge release-1.6 bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.6.3 - 2025-03-06
+
+### Fix
+
+- Undermine quests can roll over progress after weekly reset
+- Side Gig quests rotations are now correctly identified and tracked
+
 ## v1.6.2 - 2025-03-04
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.6.1 - 2025-03-03
+
+### Fix
+
+- Spider progress now will not display rewards received time after Pact completion.
+- Resolved a Tooltip crash that occasionally occurred when hovering over the reward header.
+- The progress of or "The Theater Troupe" and "Rollin' Down in the Deeps" now can rollover after weekly reset.
+
 ## v1.6.0 - 2025-03-01
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.6.2 - 2025-03-04
+
+### Fix
+
+- Worldsoul quest now can recognize new Undermine tasks.
+- Delves: Worldwide Research can be tracked now.
+
 ## v1.6.1 - 2025-03-03
 
 ### Fix

--- a/Core/Progress.lua
+++ b/Core/Progress.lua
@@ -72,6 +72,8 @@ function RewardProgress:Init(reward)
 	self.state = PROGRESS_STATE.NOT_STARTED
 	self.pendingObjectives = {}
 	self.fulfilledObjectives = {}
+	self.startedAt = nil
+	self.claimedAt = nil
 
 	local factionNameToEnum = { ["Alliance"] = 1, ["Horde"] = 2 }
 

--- a/Core/Reward.lua
+++ b/Core/Reward.lua
@@ -159,24 +159,6 @@ local function GetCachedQuestRewardItems(quest)
 
 	if #questRewardItemsCache[quest] > 0 then
 		return questRewardItemsCache[quest]
-	elseif questRewardItemsCache[quest].items and questRewardItemsCache[quest].currencies then
-		local items = {}
-		for _, item in ipairs(questRewardItemsCache[quest].items) do
-			table.insert(items, item)
-		end
-		for _, item in ipairs(questRewardItemsCache[quest].currencies) do
-			table.insert(items, item)
-		end
-
-		questRewardItemsCache[quest].items = nil
-		questRewardItemsCache[quest].currencies = nil
-
-		questRewardItemsCache[quest] = items
-		return items
-	elseif questRewardItemsCache[quest].items then
-		return questRewardItemsCache[quest].items
-	elseif questRewardItemsCache[quest].currencies then
-		return questRewardItemsCache[quest].currencies
 	end
 
 	if questRewardItemsCache[quest].items == nil then
@@ -207,18 +189,35 @@ local function GetCachedQuestRewardItems(quest)
 
 		for i = 1, numCurrencies do
 			local currency = C_QuestLog.GetQuestRewardCurrencyInfo(quest, i, numChoice > 0)
-			table.insert(items, {
-				id = currency.currencyID,
-				name = currency.name,
-				texture = currency.texture,
-				amount = currency.bonusRewardAmount ~= 0 and currency.bonusRewardAmount or currency.baseRewardAmount,
-				quality = currency.quality,
-			})
+			if currency then
+				table.insert(items, {
+					id = currency.currencyID,
+					name = currency.name,
+					texture = currency.texture,
+					amount = currency.bonusRewardAmount ~= 0 and currency.bonusRewardAmount or currency.baseRewardAmount,
+					quality = currency.quality,
+				})
+			end
 		end
 
-		if numCurrencies > 0 then
+		if #items == numCurrencies then
 			questRewardItemsCache[quest].currencies = items
 		end
+	end
+
+	do
+		local items = {}
+		for _, item in ipairs(questRewardItemsCache[quest].items or {}) do
+			table.insert(items, item)
+		end
+		for _, item in ipairs(questRewardItemsCache[quest].currencies or {}) do
+			table.insert(items, item)
+		end
+
+		if questRewardItemsCache[quest].items and questRewardItemsCache[quest].currencies then
+			questRewardItemsCache[quest] = items
+		end
+		return items
 	end
 end
 

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -369,6 +369,16 @@ namespace.DB.rewardCandidiates["tww"] = {
 			{ quest = 86177 }, -- Side Gig: The Tides Provide
 			{ quest = 86178 }, -- Side Gig: Cleanin' the Coast
 			{ quest = 86179 }, -- Side Gig: Lucky Break's Big Break
+
+			{ quest = 85914 }, -- Side Gig: Coolant Matters
+			{ quest = 85944 }, -- Side Gig: Blood Type
+			{ quest = 85945 }, -- Side Gig: Blood-B-Gone
+			{ quest = 85960 }, -- Side Gig: Lost in the Sauce
+
+			{ quest = 85553 }, -- Side Gig: Feeling Crabby
+			{ quest = 85913 }, -- Side Gig: Cleanup Detail
+			{ quest = 85962 }, -- Side Gig: Unseemly Reagents
+			{ quest = 86180 }, -- Side Gig: Infested Waters
 		},
 	},
 	{

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -61,15 +61,17 @@ namespace.DB.rewardCandidiates["tww"] = {
 		description = "Delves Meta Quest",
 		group = RewardsGroup.PINNACLE_CACHE,
 		minimumLevel = 70,
+		timeLeft = function()
+			local questDuration = 21 * SECONDS_PER_DAY
+			local questWeek = time({ year = 2025, month = 2, day = 24 })
+
+			local now = GetServerTime()
+			local timeStarted = questWeek + ((now + C_DateAndTime.GetSecondsUntilWeeklyReset() - questWeek) % (7 * SECONDS_PER_DAY))
+
+			return questDuration - ((now - timeStarted) % questDuration)
+		end,
 		entries = {
-			{ quest = 82746 }, -- Delves: Breaking Tough to Loot Stuff
-			{ quest = 82707 }, -- Delves: Earthen Defense
-			{ quest = 82710 }, -- Delves: Empire-ical Exploration
-			{ quest = 82706 }, -- Delves: Khaz Algar Research
-			{ quest = 82711 }, -- Delves: Lost and Found
-			{ quest = 82708 }, -- Delves: Nerubian Menace
-			{ quest = 82709 }, -- Delves: Percussive Archaeology
-			{ quest = 82712 }, -- Delves: Trouble Up and Down Khaz Algar
+			{ quest = 82706 }, -- Delves: Worldwide Research
 		},
 	},
 	{

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -207,6 +207,7 @@ namespace.DB.rewardCandidiates["tww"] = {
 		description = "Collect wax for Kobolds",
 		group = RewardsGroup.WEEKLY_CACHE,
 		minimumLevel = 80,
+		rollover = true,
 		entries = {
 			{ quest = 82946 }, -- Rollin' Down in the Deeps
 		},

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -186,6 +186,7 @@ namespace.DB.rewardCandidiates["tww"] = {
 		key = "Troupe",
 		group = RewardsGroup.WEEKLY_CACHE,
 		minimumLevel = 80,
+		rollover = true,
 		entries = {
 			{ quest = 83240 }, -- The Theater Troupe
 		},

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -121,6 +121,11 @@ namespace.DB.rewardCandidiates["tww"] = {
 					82509, -- Worldsoul: Nerub-ar Palace [LFR]
 					82659, -- Worldsoul: Nerub-ar Palace [N]
 					82510, -- Worldsoul: Nerub-ar Palace [H]
+					87417, -- Worldsoul: Dungeons
+					87419, -- Worldsoul: Delves
+					87422, -- Worldsoul: Undermine World Quests
+					87423, -- Worldsoul: Undermine Explorer
+					87424, -- Worldsoul: World Bosses
 				},
 			},
 		},

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -354,6 +354,7 @@ namespace.DB.rewardCandidiates["tww"] = {
 		key = "Surge",
 		group = RewardsGroup.WEEKLY_CACHE,
 		minimumLevel = 80,
+		rollover = true,
 		entries = {
 			{ quest = 86775 }, -- Urge to Surge
 		},
@@ -386,6 +387,7 @@ namespace.DB.rewardCandidiates["tww"] = {
 		key = "Shipping",
 		group = RewardsGroup.UNDERMINE,
 		minimumLevel = 80,
+		rollover = true,
 		entries = {
 			{ quest = 85869 }, -- Many Jobs, Handle It!
 		},
@@ -395,6 +397,7 @@ namespace.DB.rewardCandidiates["tww"] = {
 		key = "SCRAP",
 		group = RewardsGroup.UNDERMINE,
 		minimumLevel = 80,
+		rollover = true,
 		entries = {
 			{ quest = 85879 }, -- Reduce, Reuse, Resell
 		},

--- a/GUI/Main.lua
+++ b/GUI/Main.lua
@@ -443,7 +443,7 @@ function Main:AddCharacterColumns()
 			end,
 		},
 		{
-			name = "Fraction",
+			name = "Faction",
 			key = "factionName",
 			width = 60,
 			align = "CENTER",

--- a/WeeklyRewards.lua
+++ b/WeeklyRewards.lua
@@ -42,6 +42,21 @@ function WeeklyRewards:Redraw()
 	Main:Redraw()
 end
 
+function WeeklyRewards:MigrateDB()
+	local candidates = {}
+	for _, candidate in ipairs(DB:GetAllCandidates()) do
+		candidates[candidate.id] = candidate
+	end
+
+	for _, reward in ipairs(self.db.global.activeRewards) do
+		local candidate = candidates[reward.id]
+		if candidate and reward.rollover ~= candidate.rollover then
+			reward.rollover = candidate.rollover
+			Util:Debug("v1.6.3: Rewards rollover migrated: ", reward.id, reward.rollover)
+		end
+	end
+end
+
 function WeeklyRewards:OnInitialize()
 	_G["BINDING_NAME_WeeklyRewards"] = "Show/Hide the window"
 	self:RegisterChatCommand("wr", "ExecuteChatCommands")
@@ -71,6 +86,8 @@ function WeeklyRewards:OnInitialize()
 	})
 	LibDBIcon:Register(addonName, WRLDB, self.db.global.minimap)
 	LibDBIcon:AddButtonToCompartment(addonName)
+
+	self:MigrateDB()
 end
 
 function WeeklyRewards:OnEnable()


### PR DESCRIPTION
### Fix

- Undermine quests can roll over progress after weekly reset
- Side Gig quests rotations are now correctly identified and tracked
- Worldsoul quest now can recognize new Undermine tasks.
- Delves: Worldwide Research can be tracked now.
- Spider progress now will not display rewards received time after Pact completion.
- Resolved a Tooltip crash that occasionally occurred when hovering over the reward header.
- The progress of or "The Theater Troupe" and "Rollin' Down in the Deeps" now can rollover after weekly reset.