### PR TITLE
Merge release-1.7 bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.1 - 2025-03-12
+
+### Fix
+
+- Crash: When encountering a new character for the first time.
+
 ## v1.7.0 - 2025-03-11
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.7.2 - 2025-03-13
+
+### Fix
+
+- Archives quest progress is stuck at First Disc.
+- Cannot recognize Dungeon reward when Operation: Floodgate is the active quest.
+- Spider progress failed to rollover before signing a pact.
+- Active rewards occasionally failed to update after reset.
+
 ## v1.7.1 - 2025-03-12
 
 ### Fix

--- a/Core/Character.lua
+++ b/Core/Character.lua
@@ -207,11 +207,11 @@ function Character:Scan(activeRewards)
 		end
 
 		local progress = self.progress[reward.id]
-		if reward:HasQuestPool() and not progress:hasClaimed() then
+		if progress == nil or next(progress) == nil or progress:ObjectivesCount() == 0 then
 			return true
 		end
 
-		if progress == nil or next(progress) == nil or progress:ObjectivesCount() == 0 then
+		if reward:HasQuestPool() and not progress:hasClaimed() then
 			return true
 		end
 

--- a/Core/Progress.lua
+++ b/Core/Progress.lua
@@ -98,7 +98,12 @@ function RewardProgress:Init(reward)
 				end
 			end
 		else
-			if objective.unlockQuest and objective.unlockUntilReset and not WAPI_IsQuestFlaggedCompleted(objective.unlockQuest) then
+			if
+				objective.unlockQuest
+				and objective.unlockUntilReset
+				and not WAPI_IsQuestFlaggedCompleted(objective.unlockQuest)
+				and not WAPI_IsOnQuest(objective.quest)
+			then
 				Util:Debug("Track only UnlockQuest:", reward.name)
 
 				objective = { quest = objective.unlockQuest }
@@ -165,7 +170,7 @@ function RewardProgress:_UpdateRecords()
 		end
 
 		local quest = reward.unlockQuest or reward.quest
-		if reward.unlockQuest and WAPI_IsQuestFlaggedCompleted(reward.unlockQuest) then
+		if reward.unlockQuest and (WAPI_IsQuestFlaggedCompleted(reward.unlockQuest) or WAPI_IsOnQuest(reward.quest)) then
 			quest = reward.quest
 		end
 		for _, objective in ipairs(WAPI_GetQuestObjectives(quest) or {}) do

--- a/Core/Reward.lua
+++ b/Core/Reward.lua
@@ -153,9 +153,9 @@ function Reward:HasConfirmed()
 	return self.state == STATE.CONFIRMED
 end
 
-function Reward:HasQuestPool()
+function Reward:HasQuestPool(includeLocked)
 	for _, o in ipairs(self.objectives) do
-		if o.questPool then
+		if o.questPool and (includeLocked or o.unlockQuest == nil) then
 			return true
 		end
 	end

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -234,6 +234,7 @@ namespace.DB.rewardCandidiates["tww"] = {
 			{ quest = 83459 }, -- The Dawnbreaker
 			{ quest = 83432 }, -- The Rookery
 			{ quest = 83457 }, -- The Stonevault
+			{ quest = 86203 }, -- Operation: Floodgate
 		},
 	},
 	{

--- a/WeeklyRewards.lua
+++ b/WeeklyRewards.lua
@@ -153,6 +153,7 @@ function WeeklyRewards:OnEnable()
 		{
 			"CALENDAR_UPDATE_EVENT_LIST",
 			"PLAYER_LEVEL_CHANGED",
+			"PLAYER_ENTERING_WORLD",
 			"QUEST_ACCEPTED",
 		},
 		3,


### PR DESCRIPTION
### Fix

- Archives quest progress is stuck at First Disc.
- Cannot recognize Dungeon reward when Operation: Floodgate is the active quest.
- Spider progress failed to rollover before signing a pact.
- Active rewards occasionally failed to update after reset.
- Crash: When encountering a new character for the first time.