### PR TITLE
Merge release-1.8 bugfixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.8.2 - 2025-04-08
+
+### Fix
+
+- Crash when Cyrce Circlet is not equipped.
+- Progress "Started At" is set to now sometimes.
+
 ## v1.8.1 - 2025-04-03
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.8.1 - 2025-04-03
+
+### Fix
+
+- Player location is not updated when switching to a new map.
+- C.H.E.T.T progress is stuck at 4/5.
+- Worldsoul meta quest is not rollover-able in 11.1.
+
 ## v1.8.0 - 2025-03-29
 
 ## New Features

--- a/Core/CyrceCircletProgress.lua
+++ b/Core/CyrceCircletProgress.lua
@@ -36,7 +36,7 @@ local function GetRingItemLevel()
 	end
 
 	if not item then
-		Debug("Cannot find the ring")
+		Util:Debug("Cannot find the ring")
 		return 0
 	end
 
@@ -64,8 +64,8 @@ function CyrceCircletProgress:_UpdateRecords()
 	local iLvl = GetRingItemLevel()
 	self.position, self.total = GetRingRank(iLvl)
 	table.insert(self.records, {
-		text = format("%s (%d)", self:GetCachedItemName(RING_ITEM_ID), iLvl),
-		fulfilled = 1,
+		text = self:GetCachedItemName(RING_ITEM_ID) .. (iLvl > 0 and format(" (%d)", iLvl) or ""),
+		fulfilled = iLvl > 0 and 1 or 0,
 		required = 1,
 	})
 

--- a/Core/Progress.lua
+++ b/Core/Progress.lua
@@ -304,8 +304,6 @@ function RewardProgress:Update(completedQuest)
 		self:_UpdateRecords()
 		if self.position > 0 or WAPI_IsOnQuest(self.pendingObjectives[1].quest) then
 			newState = PROGRESS_STATE.IN_PROGRESS
-		else
-			newState = PROGRESS_STATE.NOT_STARTED
 		end
 
 		if self.total == 0 then

--- a/Core/Progress.lua
+++ b/Core/Progress.lua
@@ -85,14 +85,18 @@ function RewardProgress:Init(reward)
 			for i, quest in ipairs(objective.questPool) do
 				local unlockProfession = objective.unlockProfession and objective.unlockProfession[i]
 
-				if objective.maxCompletion and WAPI_IsQuestFlaggedCompleted(quest) then
+				if
+					objective.maxCompletion
+					and WAPI_IsQuestFlaggedCompleted(quest)
+					and (objective.unlockItem == nil or WAPI_GetItemCount(objective.unlockItem) > 0)
+				then
 					table.insert(self.fulfilledObjectives, { quest = quest, prior = true })
 					numCompleted = numCompleted + 1
 					if numCompleted >= objective.maxCompletion then
 						break
 					end
 				elseif
-					WAPI_IsOnQuest(quest)
+					WAPI_IsOnQuest(quest) and (objective.unlockItem == nil or WAPI_GetItemCount(objective.unlockItem) > 0)
 					or unlockProfession and Util:IsProfessionLearned(unlockProfession)
 					or (objective.unlockQuest and WAPI_IsQuestFlaggedCompleted(
 						type(objective.unlockQuest) == "table" and objective.unlockQuest[i] or objective.unlockQuest

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -429,6 +429,7 @@ namespace.DB.rewardCandidiates["tww"] = {
 			{
 				quest = 0,
 				maxCompletion = 4,
+				unlockItem = 235053,
 				questPool = {
 					86915, -- Side with a Cartel
 					86917, -- Ship Right

--- a/DB/TWW.lua
+++ b/DB/TWW.lua
@@ -81,7 +81,6 @@ namespace.DB.rewardCandidiates["tww"] = {
 		key = "Worldsoul",
 		description = "The Call of the Worldsoul",
 		group = RewardsGroup.PINNACLE_CACHE,
-		rollover = true,
 		minimumLevel = 70,
 		entries = {
 			{

--- a/WeeklyRewards.lua
+++ b/WeeklyRewards.lua
@@ -147,6 +147,10 @@ function WeeklyRewards:OnEnable()
 		character:UpdateLocation()
 	end)
 
+	self:RegisterEvent("ZONE_CHANGED_NEW_AREA", function(event)
+		character:UpdateLocation()
+	end)
+
 	self:RegisterBucketEvent(
 		{
 			"ITEM_PUSH",

--- a/WeeklyRewards.lua
+++ b/WeeklyRewards.lua
@@ -54,6 +54,15 @@ function WeeklyRewards:MigrateDB()
 				end
 			end
 			Util:Debug("v1.8.0: Delves group migrated")
+		elseif reward.id == "tww-chett" and #reward.objectives == 2 and reward.objectives[2].unlockItem == nil then
+			reward.objectives[2].unlockItem = 235053
+			for _, c in pairs(self.db.global.characters) do
+				if c.progress and c.progress["tww-chett"] and c.progress["tww-chett"].position == 4 and c.progress["tww-chett"].total == 5 then
+					c.progress["tww-chett"] = nil
+					Util:Debug("v1.8.1: tww-chett reset:", c.name)
+				end
+			end
+			Util:Debug("v1.8.1: tww-chett migrated")
 		end
 	end
 end


### PR DESCRIPTION
### Fix

- Crash when Cyrce Circlet is not equipped.
- Progress "Started At" is set to now sometimes.
- Player location is not updated when switching to a new map.
- C.H.E.T.T progress is stuck at 4/5.
- Worldsoul meta quest is not rollover-able in 11.1.