### PR TITLE
feat: character item level column and list-aware sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ Embeds/
 
 # pkgmeta local
 .release/
+
+# Cursor / IDE
+.cursor/

--- a/Core/Character.lua
+++ b/Core/Character.lua
@@ -11,6 +11,8 @@ local Character = {
 	factionName = "",
 	class = "",
 	location = "",
+	---@type number[]|nil  -- { GetAverageItemLevel() } — overall, equipped, PvP
+	itemLevels = nil,
 }
 namespace.Character = Character
 
@@ -19,6 +21,7 @@ local ProgressFactory = namespace.ProgressFactory
 
 local WAPI = {
 	GetServerTime = GetServerTime,
+	GetAverageItemLevel = GetAverageItemLevel,
 }
 
 local Cache = {
@@ -226,10 +229,24 @@ function Character:ReceiveDrop(guid, quantity, itemId, currencyId)
 end
 
 -- Reset progress, replace old with new one
+function Character:UpdateItemLevels()
+	if not self:IsCurrentPlayer() then
+		return
+	end
+
+	local overall, equipped, pvp = WAPI.GetAverageItemLevel()
+	if type(equipped) ~= "number" and type(overall) ~= "number" then
+		return
+	end
+
+	self.itemLevels = { overall, equipped, pvp }
+end
+
 function Character:Scan(activeRewards)
 	-- Reset level and etc
 	self.level = UnitLevel("player")
 	self:UpdateCovenant()
+	self:UpdateItemLevels()
 
 	local rewardsToScan = Util:Filter(activeRewards, function(reward)
 		if not reward:PlayerMeetsRequiredLevel(self.level) then

--- a/Core/Character.lua
+++ b/Core/Character.lua
@@ -228,20 +228,15 @@ function Character:ReceiveDrop(guid, quantity, itemId, currencyId)
 	progress:AddReward(currencyId, itemId, quantity, true)
 end
 
--- Reset progress, replace old with new one
 function Character:UpdateItemLevels()
-	if not self:IsCurrentPlayer() then
-		return
-	end
-
-	local overall, equipped, pvp = WAPI.GetAverageItemLevel()
-	if type(equipped) ~= "number" and type(overall) ~= "number" then
-		return
-	end
-
-	self.itemLevels = { overall, equipped, pvp }
+	self.itemLevels = { WAPI.GetAverageItemLevel() }
 end
 
+function Character:GetAverageItemLevel()
+	return unpack(self.itemLevels or {})
+end
+
+-- Reset progress, replace old with new one
 function Character:Scan(activeRewards)
 	-- Reset level and etc
 	self.level = UnitLevel("player")

--- a/Core/CharacterStore.lua
+++ b/Core/CharacterStore.lua
@@ -20,6 +20,21 @@ local Cache = {
 	fieldIndex = nil,
 }
 
+local function SafeDictComparator(lhs, rhs, field)
+	lhs = lhs and lhs[field] or nil
+	rhs = rhs and rhs[field] or nil
+
+	if lhs == rhs then
+		return 0
+	elseif lhs == nil then
+		return -1
+	elseif rhs == nil then
+		return 1
+	end
+
+	return lhs < rhs and -1 or 1
+end
+
 local function CharacterComparator(lhs, rhs, field)
 	if lhs == rhs then
 		return 0
@@ -32,15 +47,7 @@ local function CharacterComparator(lhs, rhs, field)
 	local data = Cache.instance:CurrentPlayer()[field]
 
 	if data and type(data) ~= "table" then
-		if lhs[field] == rhs[field] then
-			return 0
-		elseif lhs[field] == nil then
-			return -1
-		elseif rhs[field] == nil then
-			return 1
-		end
-
-		return lhs[field] < rhs[field] and -1 or 1
+		return SafeDictComparator(lhs, rhs, field)
 	end
 
 	local flatField = Cache.flatField
@@ -49,15 +56,7 @@ local function CharacterComparator(lhs, rhs, field)
 		field = Cache.fieldIndex or 1
 	end
 
-	if lhs[flatField][field] == rhs[flatField][field] then
-		return 0
-	elseif lhs[flatField][field] == nil then
-		return -1
-	elseif rhs[flatField][field] == nil then
-		return 1
-	end
-
-	return lhs[flatField][field] < rhs[flatField][field] and -1 or 1
+	return SafeDictComparator(lhs[flatField], rhs[flatField], field)
 end
 
 local function CreateCharacterSorter(primary, secondary, ascending, secondaryAscending)

--- a/Core/CharacterStore.lua
+++ b/Core/CharacterStore.lua
@@ -17,6 +17,7 @@ local Cache = {
 	ascending = true,
 	secondaryAscending = true,
 	flatField = "",
+	fieldIndex = nil,
 }
 
 local function CharacterComparator(lhs, rhs, field)
@@ -28,7 +29,9 @@ local function CharacterComparator(lhs, rhs, field)
 		return -1
 	end
 
-	if Cache.instance:CurrentPlayer()[field] then
+	local data = Cache.instance:CurrentPlayer()[field]
+
+	if data and type(data) ~= "table" then
 		if lhs[field] == rhs[field] then
 			return 0
 		elseif lhs[field] == nil then
@@ -41,6 +44,10 @@ local function CharacterComparator(lhs, rhs, field)
 	end
 
 	local flatField = Cache.flatField
+	if type(data) == "table" and #data > 0 then
+		flatField = field
+		field = Cache.fieldIndex or 1
+	end
 
 	if lhs[flatField][field] == rhs[flatField][field] then
 		return 0
@@ -131,15 +138,16 @@ function CharacterStore:GetSortOrder()
 	return Cache.sortOrder, Cache.ascending
 end
 
-function CharacterStore:SetSortOrder(field)
-	if Cache.sortOrder == field then
-		Cache.ascending = not Cache.ascending
-	else
+function CharacterStore:SetSortOrder(field, index)
+	if Cache.sortOrder ~= field then
 		Cache.secondarySortOrder = Cache.sortOrder
 		Cache.secondaryAscending = Cache.ascending
+	elseif not index then
+		Cache.ascending = not Cache.ascending
 	end
 
 	Cache.sortOrder = field
+	Cache.fieldIndex = index
 
 	Util:Debug("Sorting:", Cache.sortOrder, Cache.secondarySortOrder, Cache.ascending, Cache.secondaryAscending)
 end

--- a/GUI/Main.lua
+++ b/GUI/Main.lua
@@ -592,54 +592,29 @@ function Main:AddCharacterColumns()
 			end,
 		},
 		{
-			name = L["column_item_level"],
+			name = ITEM_LEVEL_ABBR,
 			key = "itemLevels",
-			width = 56,
+			width = 40,
 			align = "CENTER",
 			cell = function(character)
-				local il = character.itemLevels
-				local overall = type(il) == "table" and il[1]
-				local equipped = type(il) == "table" and il[2]
-				local pvpIl = type(il) == "table" and il[3]
-				local text = "-"
-				if type(equipped) == "number" then
-					if type(overall) == "number" and overall > equipped then
-						text = format("%d (%d)", equipped, overall)
-					else
-						text = tostring(equipped)
-					end
-				elseif type(overall) == "number" then
-					text = tostring(overall)
-				end
-
+				local avgItemLevel, avgItemLevelEquipped, avgItemLevelPvP = character:GetAverageItemLevel()
 				return {
-					text = text,
+					text = avgItemLevel and floor(avgItemLevel) or "-",
 					onEnter = function(cellFrame)
 						GameTooltip:SetOwner(cellFrame, "ANCHOR_RIGHT")
-						GameTooltip:SetText(L["column_item_level"], HIGHLIGHT_FONT_COLOR:GetRGB())
-						if type(overall) == "number" or type(equipped) == "number" then
-							GameTooltip:AddLine(" ")
-							if type(equipped) == "number" then
-								GameTooltip:AddDoubleLine(
-									STAT_AVERAGE_ITEM_LEVEL_EQUIPPED,
-									WHITE_FONT_COLOR:WrapTextInColorCode(tostring(equipped))
-								)
-							end
-							if type(overall) == "number" and overall ~= equipped then
-								GameTooltip:AddDoubleLine(
-									STAT_AVERAGE_ITEM_LEVEL,
-									WHITE_FONT_COLOR:WrapTextInColorCode(tostring(overall))
-								)
-							end
-							if type(pvpIl) == "number" then
-								GameTooltip:AddDoubleLine(
-									L["column_item_level_pvp"],
-									WHITE_FONT_COLOR:WrapTextInColorCode(tostring(pvpIl))
-								)
-							end
+
+						if not avgItemLevel then
+							GameTooltip:SetText(L["table_alts_collect_hint"], GREEN_FONT_COLOR:GetRGB())
 						else
+							local title = format("%s %d", STAT_AVERAGE_ITEM_LEVEL, avgItemLevel)
+							if avgItemLevelEquipped ~= avgItemLevel then
+								title = title .. "  " .. STAT_AVERAGE_ITEM_LEVEL_EQUIPPED:format(avgItemLevelEquipped)
+							end
+							GameTooltip:SetText(title, HIGHLIGHT_FONT_COLOR:GetRGB())
+
+							GameTooltip:AddLine(STAT_AVERAGE_ITEM_LEVEL_TOOLTIP)
 							GameTooltip:AddLine(" ")
-							GameTooltip:AddLine(L["column_item_level_unknown"], GRAY_FONT_COLOR:GetRGB())
+							GameTooltip:AddLine(PVP_RATING_LINK_ITEM_LEVEL:format(avgItemLevelPvP))
 						end
 						GameTooltip:Show()
 					end,

--- a/GUI/Main.lua
+++ b/GUI/Main.lua
@@ -592,6 +592,62 @@ function Main:AddCharacterColumns()
 			end,
 		},
 		{
+			name = L["column_item_level"],
+			key = "itemLevels",
+			width = 56,
+			align = "CENTER",
+			cell = function(character)
+				local il = character.itemLevels
+				local overall = type(il) == "table" and il[1]
+				local equipped = type(il) == "table" and il[2]
+				local pvpIl = type(il) == "table" and il[3]
+				local text = "-"
+				if type(equipped) == "number" then
+					if type(overall) == "number" and overall > equipped then
+						text = format("%d (%d)", equipped, overall)
+					else
+						text = tostring(equipped)
+					end
+				elseif type(overall) == "number" then
+					text = tostring(overall)
+				end
+
+				return {
+					text = text,
+					onEnter = function(cellFrame)
+						GameTooltip:SetOwner(cellFrame, "ANCHOR_RIGHT")
+						GameTooltip:SetText(L["column_item_level"], HIGHLIGHT_FONT_COLOR:GetRGB())
+						if type(overall) == "number" or type(equipped) == "number" then
+							GameTooltip:AddLine(" ")
+							if type(equipped) == "number" then
+								GameTooltip:AddDoubleLine(
+									STAT_AVERAGE_ITEM_LEVEL_EQUIPPED,
+									WHITE_FONT_COLOR:WrapTextInColorCode(tostring(equipped))
+								)
+							end
+							if type(overall) == "number" and overall ~= equipped then
+								GameTooltip:AddDoubleLine(
+									STAT_AVERAGE_ITEM_LEVEL,
+									WHITE_FONT_COLOR:WrapTextInColorCode(tostring(overall))
+								)
+							end
+							if type(pvpIl) == "number" then
+								GameTooltip:AddDoubleLine(
+									L["column_item_level_pvp"],
+									WHITE_FONT_COLOR:WrapTextInColorCode(tostring(pvpIl))
+								)
+							end
+						else
+							GameTooltip:AddLine(" ")
+							GameTooltip:AddLine(L["column_item_level_unknown"], GRAY_FONT_COLOR:GetRGB())
+						end
+						GameTooltip:Show()
+					end,
+					onLeave = GameTooltip_Hide,
+				}
+			end,
+		},
+		{
 			name = FACTION,
 			key = "factionName",
 			width = 50,

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -46,9 +46,6 @@ L["column_realm"] = "Realm"
 L["column_covenant"] = "Covenant"
 L["column_location"] = "Location"
 L["column_last_update"] = "LastUpdate"
-L["column_item_level"] = "Item Level"
-L["column_item_level_unknown"] = "Log in on this character to record item level."
-L["column_item_level_pvp"] = "PvP item level"
 
 -- Covenant tooltips
 L["covenant_sanctum_unknown"] = "Sanctum Upgrade status is unknown"
@@ -57,7 +54,7 @@ L["covenant_not_joined"] = "This character has not join any Covenant"
 -- Table tooltips
 L["table_sort_hint"] = "<Left Click to Sort>"
 L["table_reset_progress_hint"] = "<Ctrl click to reset the progress>"
-L["table_alts_collect_hint"] = "Log in with this character to collect it"
+L["table_alts_collect_hint"] = "Log in on this character to collect it"
 
 -- Progress tooltips
 L["progress_rewards_received_at"] = "Rewards Received At:"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -46,6 +46,9 @@ L["column_realm"] = "Realm"
 L["column_covenant"] = "Covenant"
 L["column_location"] = "Location"
 L["column_last_update"] = "LastUpdate"
+L["column_item_level"] = "Item Level"
+L["column_item_level_unknown"] = "Log in on this character to record item level."
+L["column_item_level_pvp"] = "PvP item level"
 
 -- Covenant tooltips
 L["covenant_sanctum_unknown"] = "Sanctum Upgrade status is unknown"

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -48,6 +48,9 @@ L["column_realm"] = "Игровой мир"
 L["column_covenant"] = "Ковенант"
 L["column_location"] = "Местоположение"
 L["column_last_update"] = "Обновлено"
+L["column_item_level"] = "Уровень предметов"
+L["column_item_level_unknown"] = "Зайдите этим персонажем, чтобы записать уровень предметов."
+L["column_item_level_pvp"] = "Ур. предметов (PvP)"
 
 -- Covenant tooltips
 L["covenant_sanctum_unknown"] = "Статус обновления Обители неизвестен"

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -48,9 +48,6 @@ L["column_realm"] = "Игровой мир"
 L["column_covenant"] = "Ковенант"
 L["column_location"] = "Местоположение"
 L["column_last_update"] = "Обновлено"
-L["column_item_level"] = "Уровень предметов"
-L["column_item_level_unknown"] = "Зайдите этим персонажем, чтобы записать уровень предметов."
-L["column_item_level_pvp"] = "Ур. предметов (PvP)"
 
 -- Covenant tooltips
 L["covenant_sanctum_unknown"] = "Статус обновления Обители неизвестен"

--- a/WeeklyRewards.lua
+++ b/WeeklyRewards.lua
@@ -233,6 +233,14 @@ function WeeklyRewards:OnEnable()
 		character:Scan(activeRewards)
 	end)
 
+	self:RegisterEvent("PLAYER_EQUIPMENT_CHANGED", function()
+		character:UpdateItemLevels()
+	end)
+
+	self:RegisterEvent("PLAYER_AVG_ITEM_LEVEL_UPDATE", function()
+		character:UpdateItemLevels()
+	end)
+
 	self:RegisterEvent("QUEST_LOG_UPDATE", function()
 		Util:InvokeAfter(5, character.UpdateProgress, character)
 	end)


### PR DESCRIPTION
## Summary
- Add an **Item level** character table column with equipped/overall display and PvP line in the tooltip; persist `GetAverageItemLevel()` as a three-value list on each character and refresh from `Scan`, `PLAYER_EQUIPMENT_CHANGED`, and `PLAYER_AVG_ITEM_LEVEL_UPDATE`.
- Extend **CharacterStore** sorting for list-shaped character fields using `fieldIndex`, and fix the sorter so the **secondary** sort respects `secondaryAscending`.
- **Gitignore** `.cursor/` so Cursor metadata is not tracked.

**Note:** This branch also includes several commits that were already on local `main` but not yet on `origin/main` (Midnight rewards, BG secret fix, rested level coloring, XP tooltip fix).

## Test plan
- [ ] Log in, open the main window: item level shows for the current character; alts show `-` or last stored values until logged in.
- [ ] Change gear: item level updates without `/reload`.
- [ ] Sort by Item level and by other columns; confirm ascending/descending toggles and secondary sort feel correct.
- [ ] Confirm `.cursor/` does not appear in `git status` after normal Cursor use.