### PR TITLE
feat: per-character notes on the name column

### DIFF
--- a/Core/Character.lua
+++ b/Core/Character.lua
@@ -475,3 +475,13 @@ function Character:AddPartyToTooltip(tooltip, instruction)
 		tooltip:AddLine(format("%s%s - %s%s|r", color:GenerateHexColorMarkup(), name, realm or "", warbandIcon))
 	end
 end
+
+function Character:SetNote(text)
+	self.note = strtrim(text)
+	Util:Debug("Comment updated:", self.note)
+end
+
+function Character:GetNote()
+	local prefix = string.split(" ", self.note or "")
+	return self.note or "", prefix
+end

--- a/GUI/Dialogs.lua
+++ b/GUI/Dialogs.lua
@@ -1,0 +1,43 @@
+local addonName, namespace = ...
+
+local L = namespace.L
+local Util = namespace.Util
+
+local CHARACTER_NOTE = {
+	text = SET_FRIENDNOTE_LABEL,
+	button1 = OKAY,
+	button2 = CANCEL,
+	hasEditBox = true,
+	editBoxWidth = 350,
+	maxLetters = 48,
+	OnShow = function(dialog, character)
+		local editBox = dialog:GetEditBox()
+		editBox:SetText(character:GetNote())
+		editBox:SetFocus()
+	end,
+	OnAccept = function(dialog, character)
+		character:SetNote(dialog:GetEditBox():GetText())
+		namespace.GUIMain:Redraw()
+	end,
+	EditBoxOnEnterPressed = function(editBox, data)
+		editBox:GetParent():GetButton1():Click()
+	end,
+	EditBoxOnEscapePressed = StaticPopup_StandardEditBoxOnEscapePressed,
+	timeout = 0,
+	whileDead = 1,
+	hideOnEscape = 1,
+}
+
+local Dialogs = {}
+
+function Dialogs.ShowCharacterNote(character)
+	local tag = addonName .. "_CharacterNote"
+
+	if not StaticPopupDialogs[tag] then
+		StaticPopupDialogs[tag] = CHARACTER_NOTE
+	end
+
+	StaticPopup_Show(tag, Util.WrapTextInClassColor(character.class, character.name), nil, character)
+end
+
+namespace.Dialogs = Dialogs

--- a/GUI/Main.lua
+++ b/GUI/Main.lua
@@ -16,6 +16,8 @@ local CharacterStore = namespace.CharacterStore
 local ActiveRewards = namespace.ActiveRewards
 local RewardSummary = namespace.RewardSummary
 
+local Dialogs = namespace.Dialogs
+
 function Main:ToggleWindow()
 	if not self.window then
 		self:CreateWindow()
@@ -562,7 +564,29 @@ function Main:AddCharacterColumns()
 			key = "name",
 			width = 90,
 			cell = function(character)
-				return { text = Util.WrapTextInClassColor(character.class, character.name) }
+				local note, tag = character:GetNote()
+
+				tag = #tag > 0 and format(" |cnGOLD_FONT_COLOR:(%s)|r", #tag > 4 and "*" or tag) or tag
+
+				local text = Util.WrapTextInClassColor(character.class, character.name)
+				return {
+					text = text .. tag,
+					onEnter = function(cellFrame)
+						GameTooltip:SetOwner(cellFrame, "ANCHOR_RIGHT")
+						GameTooltip:SetText(text)
+						GameTooltip:AddLine(" ")
+						if #note > 0 then
+							GameTooltip:AddLine("|T131129:12|t" .. note, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, true)
+							GameTooltip:AddLine(" ")
+						end
+						GameTooltip:AddLine(CLICK_TO_ENTER_COMMENT, GREEN_FONT_COLOR:GetRGB())
+						GameTooltip:Show()
+					end,
+					onLeave = GameTooltip_Hide,
+					onClick = function()
+						Dialogs.ShowCharacterNote(character)
+					end,
+				}
 			end,
 		},
 		{

--- a/GUI/UI.xml
+++ b/GUI/UI.xml
@@ -1,0 +1,4 @@
+<Ui>
+    <Script file="Dialogs.lua" />
+    <Script file="Main.lua" />
+</Ui>

--- a/WeeklyRewards.toc
+++ b/WeeklyRewards.toc
@@ -38,8 +38,7 @@ Util.lua
 
 DB\Data.xml
 Core\Core.xml
-
-GUI\Main.lua
+GUI\UI.xml
 
 WeeklyRewards.lua
 


### PR DESCRIPTION
## Summary
- Adds optional per-character note storage (`SetNote` / `GetNote` on `Character`).
- Name column shows a short gold tag derived from the first word of the note; tooltip shows the full note and opens a Blizzard `StaticPopup` editor on click (`namespace.Dialogs`, `GUI/UI.xml` load order).

## Test plan
- [ ] Reload addon; name column renders as before when notes are empty.
- [ ] Set a short note; tag appears; tooltip shows full text; click opens edit dialog; save persists across `/reload`.
- [ ] Very long note: tag truncates sensibly; tooltip still shows full note.