### PR TITLE
fix: guard nil faction when opening main window (#32)

### DIFF
--- a/Core/Character.lua
+++ b/Core/Character.lua
@@ -228,6 +228,14 @@ function Character:ReceiveDrop(guid, quantity, itemId, currencyId)
 	progress:AddReward(currencyId, itemId, quantity, true)
 end
 
+function Character:GetFaction()
+	return self.faction or ""
+end
+
+function Character:UpdateFaction()
+	self.faction = UnitFactionGroup("player")
+end
+
 function Character:UpdateItemLevels()
 	self.itemLevels = { WAPI.GetAverageItemLevel() }
 end

--- a/GUI/Main.lua
+++ b/GUI/Main.lua
@@ -652,7 +652,7 @@ function Main:AddCharacterColumns()
 			width = 50,
 			align = "CENTER",
 			cell = function(character)
-				return { text = CreateAtlasMarkup(format("questlog-questtypeicon-%s", character.faction:lower()), 20, 20) }
+				return { text = CreateAtlasMarkup(format("questlog-questtypeicon-%s", character:GetFaction():lower()), 20, 20) }
 			end,
 		},
 		{

--- a/WeeklyRewards.lua
+++ b/WeeklyRewards.lua
@@ -222,6 +222,8 @@ function WeeklyRewards:OnEnable()
 			return
 		end
 
+		character:UpdateFaction()
+
 		if self.db.global.utils.untrackQuests then
 			character:RemoveQuestsWatch()
 		end


### PR DESCRIPTION
Fixes #32

## Summary
- Add `Character:GetFaction()` and `Character:UpdateFaction()` using `UnitFactionGroup("player")`.
- Call `UpdateFaction()` on login/reload so saved characters without `faction` get a value.
- Use `GetFaction()` in the faction column so nil `faction` no longer errors when opening the window.

## Test plan
- [ ] Open main window on a character with missing `faction` in saved data — no Lua error.
- [ ] Faction column shows Alliance/Horde icon after login.
- [ ] `/reload` — window still opens and icon remains correct.