### PR TITLE
feat: persist character column sort across reloads (#31)

### DIFF
--- a/GUI/Main.lua
+++ b/GUI/Main.lua
@@ -933,7 +933,8 @@ function Main:UpdateSortArrow()
 			else
 				CharacterStore.Get():SetSortOrder(characterField)
 				local field, ascending = CharacterStore.Get():GetSortOrder()
-				WeeklyRewards.db.global.main.characterSort = { field = field, ascending = ascending }
+				WeeklyRewards.db.global.main.sortColumn = field
+				WeeklyRewards.db.global.main.sortAscending = ascending
 			end
 
 			self:Redraw()

--- a/GUI/Main.lua
+++ b/GUI/Main.lua
@@ -932,6 +932,8 @@ function Main:UpdateSortArrow()
 				end
 			else
 				CharacterStore.Get():SetSortOrder(characterField)
+				local field, ascending = CharacterStore.Get():GetSortOrder()
+				WeeklyRewards.db.global.main.characterSort = { field = field, ascending = ascending }
 			end
 
 			self:Redraw()

--- a/WeeklyRewards.lua
+++ b/WeeklyRewards.lua
@@ -32,10 +32,8 @@ local defaultDB = {
 		},
 		main = {
 			hiddenColumns = {},
-			characterSort = {
-				field = "lastUpdate",
-				ascending = true,
-			},
+			sortColumn = "lastUpdate",
+			sortAscending = true,
 			windowScale = 100,
 			windowMaxRelativeWidth = 80,
 			windowMaxRows = 20,
@@ -156,15 +154,10 @@ function WeeklyRewards:OnEnable()
 	local characterStore = CharacterStore.Load(self.db.global.characters)
 
 	do
-		local sort = self.db.global.main.characterSort
-		if sort and sort.field then
-			local store = CharacterStore.Get()
-			if sort.field ~= "lastUpdate" or sort.ascending == false then
-				store:SetSortOrder(sort.field)
-				if not sort.ascending then
-					store:SetSortOrder(sort.field)
-				end
-			end
+		local main = self.db.global.main
+		characterStore:SetSortOrder(main.sortColumn)
+		if main.sortAscending ~= select(2, characterStore:GetSortOrder()) then
+			characterStore:SetSortOrder(main.sortColumn)
 		end
 	end
 

--- a/WeeklyRewards.lua
+++ b/WeeklyRewards.lua
@@ -32,6 +32,10 @@ local defaultDB = {
 		},
 		main = {
 			hiddenColumns = {},
+			characterSort = {
+				field = "lastUpdate",
+				ascending = true,
+			},
 			windowScale = 100,
 			windowMaxRelativeWidth = 80,
 			windowMaxRows = 20,
@@ -150,6 +154,20 @@ function WeeklyRewards:OnEnable()
 	CharacterStore:SetFlatField("progress")
 
 	local characterStore = CharacterStore.Load(self.db.global.characters)
+
+	do
+		local sort = self.db.global.main.characterSort
+		if sort and sort.field then
+			local store = CharacterStore.Get()
+			if sort.field ~= "lastUpdate" or sort.ascending == false then
+				store:SetSortOrder(sort.field)
+				if not sort.ascending then
+					store:SetSortOrder(sort.field)
+				end
+			end
+		end
+	end
+
 	local character = characterStore:CurrentPlayer()
 	local activeRewards = ActiveRewards:New(self.db.global.activeRewards)
 


### PR DESCRIPTION
Fixes #31

## Summary
- Persist character table sort field and direction in `global.main.characterSort`.
- Restore sort on login via existing `SetSortOrder` (call twice when descending).
- Save sort when clicking a column header.

## Test plan
- [ ] Sort by Name descending, `/reload` — order and arrow unchanged.
- [ ] Sort by Last Update ascending (default), `/reload` — still default order.
- [ ] Log out and back in — sort preference preserved.