### PR TITLE
feat: bump toc to 12.0.7

### DIFF
--- a/WeeklyRewards.toc
+++ b/WeeklyRewards.toc
@@ -1,4 +1,4 @@
-## Interface: 120005
+## Interface: 120007
 ## Version:  @project-version@
 
 ## Title: WeeklyRewards


### PR DESCRIPTION
## Summary
- Bump `WeeklyRewards.toc` interface version from 12.0.5 to 12.0.7 for the latest WoW retail patch.

## Test plan
- [ ] Load addon on WoW 12.0.7 client without "out of date" warning